### PR TITLE
Create winding-down.md

### DIFF
--- a/resilience/winding-down.md
+++ b/resilience/winding-down.md
@@ -1,0 +1,15 @@
+# Winding Down Sequence
+
+Use this when you want to exit flow without crash or forgetting your context.
+
+## When to Run
+- Session is ending but you’re still in the zone
+- You need to pause but you’re resisting
+
+## Steps
+1. Open `plan-now.md` and save unfinished state to `plan-now.md.bak`
+2. Open `copilot-delegate.md` and queue next file
+3. Optionally write a quick `recovery-note.md` with final state
+
+## Reminder
+Don’t process review comments or debug errors during winding down. Push them to next block


### PR DESCRIPTION
## **User description**
### **User description**
This pull request introduces a new guide for a "Winding Down Sequence" in the `resilience` folder. The guide provides structured steps to transition out of a work session without losing context or momentum.

Key additions:

* **New Guide**: Added a new file, `resilience/winding-down.md`, which outlines a sequence for exiting a flow state. It includes use cases, step-by-step instructions (e.g., saving unfinished work to a backup file and queuing the next task), and a reminder to defer non-critical tasks like reviews or debugging.


___

### **PR Type**
Documentation


___

### **Description**
- Introduces a new guide for winding down work sessions

- Details step-by-step instructions for preserving work state

- Provides reminders to defer non-critical tasks during winding down


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>winding-down.md</strong><dd><code>New guide for winding down work sessions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resilience/winding-down.md

<li>Adds a new markdown guide for winding down work sessions<br> <li> Outlines when to use the sequence and step-by-step instructions<br> <li> Includes reminders to avoid reviews or debugging during this phase


</details>


  </td>
  <td><a href="https://github.com/dmitriz/collab-frame/pull/25/files#diff-911e0ed02e4a63483712d552323a63845ac882f32e2cbeb2889a33ecbf5ec999">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add a `winding-down.md` document outlining a sequence for gracefully exiting high-focus work sessions.

### Why are these changes being made?
This document provides a structured approach to transition out of intense work sessions, ensuring ongoing work is saved and context is not lost. It helps in maintaining productivity by organizing unfinished tasks and preventing crashes or context loss.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->


___

## **CodeAnt-AI Description**
- Introduced a new markdown guide, `winding-down.md`, detailing a structured process for ending work sessions without losing context.
- The guide outlines when to initiate the winding down sequence, provides clear step-by-step instructions for preserving work state, and includes reminders to defer non-critical tasks such as reviews or debugging.
- This addition helps users exit flow states smoothly and ensures continuity for future sessions.

This PR adds a concise, actionable guide to help users transition out of productive work sessions while maintaining context and minimizing disruption. It enhances the documentation by providing practical steps and reminders for effective session management.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>winding-down.md</strong><dd><code>Add guide for structured winding down of work sessions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resilience/winding-down.md
<li>Added a new guide titled "Winding Down Sequence" for ending work <br>sessions.<br> <li> Describes when to use the sequence and provides step-by-step <br>instructions.<br> <li> Includes reminders to defer reviews and debugging during winding down.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/dmitriz/collab-frame/pull/25/files#diff-911e0ed02e4a63483712d552323a63845ac882f32e2cbeb2889a33ecbf5ec999">+15/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>