### PR TITLE
Feat/snapshot session catchup

### DIFF
--- a/scripts/snapshot-catchup.js
+++ b/scripts/snapshot-catchup.js
@@ -3,7 +3,11 @@
 const fs = require('fs');
 const path = require('path');
 
-const SNAPSHOT_PATH = path.join(__dirname, '../logs/snapshot-catchup.md');
+const SNAPSHOT_PATH = process.env.SNAPSHOT_PATH || path.join(__dirname, '../logs/snapshot-catchup.md');
+const snapshotDir = path.dirname(SNAPSHOT_PATH);
+if (!fs.existsSync(snapshotDir)) {
+  fs.mkdirSync(snapshotDir, { recursive: true });
+}
 
 const state = {
   timestamp: new Date().toISOString(),

--- a/scripts/snapshot-catchup.js
+++ b/scripts/snapshot-catchup.js
@@ -1,0 +1,40 @@
+// Purpose: Capture session state before exiting for reliable catch-up later.
+
+const fs = require('fs');
+const path = require('path');
+
+const SNAPSHOT_PATH = path.join(__dirname, '../logs/snapshot-catchup.md');
+
+const state = {
+  timestamp: new Date().toISOString(),
+  lastTask: "triage-label-review", // Replace with actual last task ID if available
+  notes: "In progress on labeling logic. Preparing freshness boost scoring.",
+  nextStepHint: "Finalize label assistant script for Copilot export.",
+  unresolvedQuestions: [
+    "Refactor triage to support freshness + importance weighting cleanly?",
+    "Collapse urgency fallback into implicit 'someday'?"
+  ]
+};
+
+function format(state) {
+  return `
+## Snapshot Catch-up
+
+**Timestamp**: ${state.timestamp}
+
+### Last Focus
+- ${state.lastTask}
+
+### Notes
+${state.notes}
+
+### Next Steps
+- ${state.nextStepHint}
+
+### Unresolved Questions
+${state.unresolvedQuestions.map(q => `- ${q}`).join('\n')}
+`.trim();
+}
+
+fs.writeFileSync(SNAPSHOT_PATH, format(state), 'utf8');
+console.log(`Snapshot written to ${SNAPSHOT_PATH}`);

--- a/scripts/snapshot-catchup.js
+++ b/scripts/snapshot-catchup.js
@@ -40,5 +40,10 @@ ${state.unresolvedQuestions.map(q => `- ${q}`).join('\n')}
 `.trim();
 }
 
-fs.writeFileSync(SNAPSHOT_PATH, format(state), 'utf8');
-console.log(`Snapshot written to ${SNAPSHOT_PATH}`);
+fs.writeFile(SNAPSHOT_PATH, format(state), { encoding: 'utf8', mode: 0o600 }, (err) => {
+  if (err) {
+    console.error(`Error writing snapshot: ${err.message}`);
+  } else {
+    console.log(`Snapshot written to ${SNAPSHOT_PATH}`);
+  }
+});

--- a/scripts/snapshot-catchup.js
+++ b/scripts/snapshot-catchup.js
@@ -23,13 +23,13 @@ function format(state) {
 **Timestamp**: ${state.timestamp}
 
 ### Last Focus
-- ${state.lastTask}
+${state.lastTask}
 
 ### Notes
 ${state.notes}
 
 ### Next Steps
-- ${state.nextStepHint}
+${state.nextStepHint}
 
 ### Unresolved Questions
 ${state.unresolvedQuestions.map(q => `- ${q}`).join('\n')}


### PR DESCRIPTION
## **User description**
### **User description**
This pull request introduces a new script, `snapshot-catchup.js`, designed to capture the current session state and save it to a markdown file for reliable task catch-up later. The script includes functionality to log task progress, notes, next steps, and unresolved questions.

Key changes:

### New feature: Session state snapshot

* Added a new script, `snapshot-catchup.js`, to record session state, including a timestamp, last task focus, notes, next steps, and unresolved questions, into a markdown file (`../logs/snapshot-catchup.md`). This is intended to improve reliability in resuming tasks after interruptions.


___

### **PR Type**
Enhancement


___

### **Description**
- Introduces `snapshot-catchup.js` script for session state capture

- Saves session details to a markdown file for task resumption

- Formats output with timestamp, last task, notes, next steps, questions


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>snapshot-catchup.js</strong><dd><code>New script for session state snapshot and markdown export</code></dd></summary>
<hr>

scripts/snapshot-catchup.js

<li>Adds a new script to capture and save session state before exit<br> <li> Defines a state object with timestamp, last task, notes, next steps, <br>and questions<br> <li> Formats session data into a markdown file for easy review<br> <li> Outputs confirmation of snapshot file creation to console


</details>


  </td>
  <td><a href="https://github.com/dmitriz/collab-frame/pull/64/files#diff-80606b4efbf756d58df6a927450acc1e1bfc0a73ce4f300175d613283e618514">+40/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a script that captures the session state to a file before exiting for reliable catch-up later.

### Why are these changes being made?

This change is essential to preserve the session state, including the time, last task, notes, next steps, and unresolved questions, to ensure that progress can be resumed effectively after interruptions. By persisting the state to a file, it facilitates smoother project management and continuity, addressing the need for manual tracking and reducing potential disruptions in workflow.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->


___

## **CodeAnt-AI Description**
- Added a new script (`snapshot-catchup.js`) that captures the current session state, including timestamp, last task, notes, next steps, and unresolved questions.
- The script formats this information into a markdown file (`../logs/snapshot-catchup.md`) for reliable task resumption after interruptions.
- Outputs a console message confirming the snapshot file creation.

This PR introduces a utility to reliably record and export session progress, making it easier to resume work after breaks or interruptions. The markdown format ensures the captured state is both human-readable and easy to reference.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>snapshot-catchup.js</strong><dd><code>Add session state snapshot script with markdown export functionality</code></dd></summary>
<hr>

scripts/snapshot-catchup.js
<li>Introduced a new script to capture and save the current session state <br>before exit.<br> <li> Defined a <code>state</code> object with timestamp, last task, notes, next steps, <br>and unresolved questions.<br> <li> Formatted the session data into a markdown file for easy review and <br>future catch-up.<br> <li> Output a confirmation message indicating successful snapshot creation.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/dmitriz/collab-frame/pull/64/files#diff-80606b4efbf756d58df6a927450acc1e1bfc0a73ce4f300175d613283e618514">+40/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>